### PR TITLE
Add Makefile support

### DIFF
--- a/alpine/lazydl/Dockerfile
+++ b/alpine/lazydl/Dockerfile
@@ -16,6 +16,7 @@ RUN apk -U update && apk -U add \
   curl \
   expect \
   git \
+  make \
   libstdc++ \
   libgcc \
   su-exec \

--- a/alpine/standalone/Dockerfile
+++ b/alpine/standalone/Dockerfile
@@ -16,6 +16,7 @@ RUN apk -U update && apk -U add \
   curl \
   expect \
   git \
+  make \
   libstdc++ \
   libgcc \
   su-exec \

--- a/ubuntu/lazydl/Dockerfile
+++ b/ubuntu/lazydl/Dockerfile
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   curl \
   expect \
   git \
+  make \
   libc6:i386 \
   libgcc1:i386 \
   libncurses5:i386 \

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   curl \
   expect \
   git \
+  make \
   libc6:i386 \
   libgcc1:i386 \
   libncurses5:i386 \


### PR DESCRIPTION
Hi,

Thanks for your work on this container, it works amazingly well!

This patch adds `make` to the list of packages installled. It's a slim 100kb package that can provide a lot of value, as makefiles are a great way to manage builds (especially in the context of CI). We use them extensively here at The Guardian to manage all the different build types we have, and being able to use them inside this container would make our lives that much easier : -)
