### PR TITLE
Allow android SDK to create files when running with host uid

### DIFF
--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -19,6 +19,7 @@ else
 fi
 
 
+chmod -R 0777 /opt/android-sdk-linux
 
 
 


### PR DESCRIPTION
Allow any user to overwrite `ANDROID_HOME/*.`

Fixes #39 