### PR TITLE
Switch to SDK 29 platform

### DIFF
--- a/tools/package-list-minimal.txt
+++ b/tools/package-list-minimal.txt
@@ -22,5 +22,5 @@ platform-tools
 platforms;android-26
 platforms;android-27
 platforms;android-28
-platforms;android-Q
+platforms;android-29
 tools

--- a/tools/package-list.txt
+++ b/tools/package-list.txt
@@ -105,7 +105,7 @@ platforms;android-25
 platforms;android-26
 platforms;android-27
 platforms;android-28
-platforms;android-Q
+platforms;android-29
 platforms;android-7
 platforms;android-8
 platforms;android-9


### PR DESCRIPTION
API 29 has been finalised and `android-Q` is not useful anymore.