### PR TITLE
Add build-tools 29 to full package list

### DIFF
--- a/tools/package-list.txt
+++ b/tools/package-list.txt
@@ -35,6 +35,7 @@ build-tools;28.0.0
 build-tools;28.0.1
 build-tools;28.0.2
 build-tools;28.0.3
+build-tools;29.0.2
 cmake;3.6.4111459
 cmake;3.10.2.4988404
 docs


### PR DESCRIPTION
It seems like it was added to the minimal list, but not the full list!