### PR TITLE
Add ability to use a custom download list with lazydl image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ This is the standard expected behaviour. The Android SDK is integrated in the do
 **Lazydl**
 Indeed, there is a lack of documentation and it might be not really intuitive to use the image in this way. The idea is to have two containers for the build process. One of which is the builing container executing the actual build. The other one is the sdk-data container, which downloads the whole SDK into a named docker volume which is shared between both containers.
 I will provide an example docker-compose file to make this more clear. Might take a couple of days, though.
+
+Lazydl can also be used to download and prepare a custom list of sdk components if you only need a portion of the sdk. Just mount a volume in at runtime pointing a list named `package-list-minimal.txt` into `/opt/tools/package-list-minimal.txt` and then run `/opt/tools/entrypoint.sh built-in`. You can also use Lazydl as a base for your own custom image.

--- a/tools/android-sdk-update.sh
+++ b/tools/android-sdk-update.sh
@@ -67,7 +67,9 @@ echo "Accepting Licenses"
 android-accept-licenses.sh "sdkmanager ${SDKMNGR_OPTS} --licenses"
 
 # https://stackoverflow.com/questions/35128229/error-no-toolchains-found-in-the-ndk-toolchains-folder-for-abi-with-prefix-llv
-( cd /opt/android-sdk-linux/ndk-bundle/toolchains \
-&& ln -sf aarch64-linux-android-4.9 mips64el-linux-android \
-&& ln -sf arm-linux-androideabi-4.9 mipsel-linux-android )
-
+if [ -d /opt/android-sdk-linux/ndk-bundle/toolchains ]
+then
+    ( cd /opt/android-sdk-linux/ndk-bundle/toolchains \
+    && ln -sf aarch64-linux-android-4.9 mips64el-linux-android \
+    && ln -sf arm-linux-androideabi-4.9 mipsel-linux-android )
+fi


### PR DESCRIPTION
This slight modification allows the use of the lazydl image for downloading a custom list of android components. Specifically it allows for not downloading the ndk-bundle which is very large.