### PR TITLE
Remove NodeJS and npm from images

### DIFF
--- a/alpine/lazydl/Dockerfile
+++ b/alpine/lazydl/Dockerfile
@@ -22,8 +22,6 @@ RUN apk -U update && apk -U add \
   libstdc++ \
   libgcc \
   mesa-dev \
-  nodejs \
-  npm \
   openjdk8 \
   pulseaudio-dev \
   su-exec \

--- a/alpine/standalone/Dockerfile
+++ b/alpine/standalone/Dockerfile
@@ -22,8 +22,6 @@ RUN apk -U update && apk -U add \
   libstdc++ \
   libgcc \
   mesa-dev \
-  nodejs \
-  npm \
   openjdk8 \
   pulseaudio-dev \
   su-exec \

--- a/ubuntu/lazydl/Dockerfile
+++ b/ubuntu/lazydl/Dockerfile
@@ -28,8 +28,6 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   vim \
   openssh-client \
   locales \
-  nodejs \
-  npm \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -28,8 +28,6 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   vim \
   openssh-client \
   locales \
-  nodejs \
-  npm \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
This fixes #68.

As a bonus images will be quite a deal slimmer.