### PR TITLE
Update to jdk-11

### DIFF
--- a/alpine/lazydl/Dockerfile
+++ b/alpine/lazydl/Dockerfile
@@ -22,7 +22,7 @@ RUN apk -U update && apk -U add \
   libstdc++ \
   libgcc \
   mesa-dev \
-  openjdk8 \
+  openjdk11 \
   pulseaudio-dev \
   su-exec \
   ncurses \

--- a/alpine/standalone/Dockerfile
+++ b/alpine/standalone/Dockerfile
@@ -22,7 +22,7 @@ RUN apk -U update && apk -U add \
   libstdc++ \
   libgcc \
   mesa-dev \
-  openjdk8 \
+  openjdk11 \
   pulseaudio-dev \
   su-exec \
   ncurses \

--- a/ubuntu/lazydl/Dockerfile
+++ b/ubuntu/lazydl/Dockerfile
@@ -22,7 +22,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   libncurses5:i386 \
   libstdc++6:i386 \
   zlib1g:i386 \
-  openjdk-8-jdk \
+  openjdk-11-jdk \
   wget \
   unzip \
   vim \

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -22,7 +22,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   libncurses5:i386 \
   libstdc++6:i386 \
   zlib1g:i386 \
-  openjdk-8-jdk \
+  openjdk-11-jdk \
   wget \
   unzip \
   vim \


### PR DESCRIPTION
AGP 7.0+ requires JDK 11 for builds; this just installs the 11 package rather than the one for 8 in the dockerfiles