### PR TITLE
Updated android sdk tools to latest version supported by Java 11

### DIFF
--- a/tools/android-env.sh
+++ b/tools/android-env.sh
@@ -5,7 +5,7 @@ export ANDROID_SDK_ROOT=${ANDROID_HOME}
 export ANDROID_SDK_HOME=${ANDROID_HOME}
 export ANDROID_SDK=${ANDROID_HOME}
 
-export PATH=${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/bin:
+export PATH=${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/bin:
 
 if [[ ! -z "$http_proxy" ]] || [[ ! -z "$https_proxy" ]]; then
     export JAVA_OPTS="-Djava.net.useSystemProxies=true $JAVA_OPTS -Dhttp.noProxyHosts=${no_proxy}"

--- a/tools/android-sdk-update.sh
+++ b/tools/android-sdk-update.sh
@@ -29,9 +29,11 @@ else
     echo "Bootstrapping SDK-Tools"
     wget -q http://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip -O sdk-tools-linux.zip \
       && unzip sdk-tools-linux.zip \
-      && mv cmdline-tools tools \
-      && touch .bootstrapped \
-      && rm sdk-tools-linux.zip
+      && cd cmdline-tools \
+      && mkdir -p latest \
+      && mv * latest \
+      ; touch .bootstrapped \
+      ; rm sdk-tools-linux.zip
 fi
 
 echo "Make sure repositories.cfg exists"

--- a/tools/android-sdk-update.sh
+++ b/tools/android-sdk-update.sh
@@ -27,13 +27,11 @@ then
     echo "SDK Tools already bootstrapped. Skipping initial setup"
 else
     echo "Bootstrapping SDK-Tools"
-    wget -q http://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip -O sdk-tools-linux.zip \
-      && unzip sdk-tools-linux.zip \
-      && cd cmdline-tools \
-      && mkdir -p latest \
-      && mv * latest \
-      ; touch .bootstrapped \
-      ; rm sdk-tools-linux.zip
+    mkdir -p cmdline-tools/latest/ \
+      && curl -sSL http://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip -o sdk-tools-linux.zip \
+      && bsdtar xvf sdk-tools-linux.zip --strip-components=1 -C cmdline-tools/latest \
+      && rm sdk-tools-linux.zip \
+      && touch .bootstrapped
 fi
 
 echo "Make sure repositories.cfg exists"

--- a/tools/android-sdk-update.sh
+++ b/tools/android-sdk-update.sh
@@ -27,7 +27,7 @@ then
     echo "SDK Tools already bootstrapped. Skipping initial setup"
 else
     echo "Bootstrapping SDK-Tools"
-    wget -q http://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O sdk-tools-linux.zip \
+    wget -q http://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip -O sdk-tools-linux.zip \
       && unzip sdk-tools-linux.zip \
       && touch .bootstrapped \
       && rm sdk-tools-linux.zip

--- a/tools/android-sdk-update.sh
+++ b/tools/android-sdk-update.sh
@@ -29,6 +29,7 @@ else
     echo "Bootstrapping SDK-Tools"
     wget -q http://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip -O sdk-tools-linux.zip \
       && unzip sdk-tools-linux.zip \
+      && mv cmdline-tools tools \
       && touch .bootstrapped \
       && rm sdk-tools-linux.zip
 fi

--- a/ubuntu/lazydl/Dockerfile
+++ b/ubuntu/lazydl/Dockerfile
@@ -28,6 +28,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   vim \
   openssh-client \
   locales \
+  bsdtar \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -28,6 +28,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   vim \
   openssh-client \
   locales \
+  bsdtar \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
Addresses issue #74 by updating to the latest cli tools (which is a slightly different format than the previous sdk tools) as mentioned [here](https://stackoverflow.com/a/58652345/5162097).

This screenshot shows the unzipped directory structure of the old zip as compared to the new tools zip and while there are differences, the `sdkmanager` tool is still located in the same relative location.
![Screen Shot 2021-08-03 at 12 04 10 PM](https://user-images.githubusercontent.com/801410/128071703-d40190b3-f22d-4713-b81d-928eb211afd6.png)
