### PR TITLE
Upgrade Ubuntu builds to a supported base image

### DIFF
--- a/ubuntu/lazydl/Dockerfile
+++ b/ubuntu/lazydl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL de.mindrunner.android-docker.flavour="ubuntu-lazydl"
 
@@ -28,7 +28,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   vim \
   openssh-client \
   locales \
-  bsdtar \
+  libarchive-tools \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -31,11 +31,10 @@ RUN apt-get install -y \
   vim \
   openssh-client \
   locales \
-  libarchive-tools
-
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+  libarchive-tools \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.UTF-8
 

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL de.mindrunner.android-docker.flavour="ubuntu-standalone"
 
@@ -31,7 +31,7 @@ RUN apt-get install -y \
   vim \
   openssh-client \
   locales \
-  bsdtar
+  libarchive-tools
 
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Tomorrow Ubuntu 18.04 will be EOL, so with minimal changes we can convert this project to Ubuntu 22 and be good for a few more years.