### PR TITLE
Bump OpenJDK

### DIFF
--- a/ubuntu/lazydl/Dockerfile
+++ b/ubuntu/lazydl/Dockerfile
@@ -22,7 +22,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
   libncurses5:i386 \
   libstdc++6:i386 \
   zlib1g:i386 \
-  openjdk-11-jdk \
+  openjdk-17-jdk \
   wget \
   unzip \
   vim \

--- a/ubuntu/standalone/Dockerfile
+++ b/ubuntu/standalone/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get install -y \
   expect \
   git \
   make \
-  openjdk-11-jdk \
+  openjdk-17-jdk \
   wget \
   unzip \
   vim \


### PR DESCRIPTION
When I try to build projects using Gradle I'm getting the following error: `Unsupported class file major version 61`

This PR should hopefully fix that.