### PR TITLE
Update package-list-minimal.txt with android-35 platform

### DIFF
--- a/tools/package-list-minimal.txt
+++ b/tools/package-list-minimal.txt
@@ -21,4 +21,5 @@ platform-tools
 platforms;android-32
 platforms;android-33
 platforms;android-34
+platforms;android-35
 tools

--- a/tools/package-list.txt
+++ b/tools/package-list.txt
@@ -28,6 +28,7 @@ platform-tools
 platforms;android-32
 platforms;android-33
 platforms;android-34
+platforms;android-35
 system-images;android-32;google_apis;x86
 system-images;android-32;google_apis;x86_64
 system-images;android-32;google_apis_playstore;x86


### PR DESCRIPTION
it's 2025 and it's more than common to use compileSdk=35 nowadays, so it should come pre-installed with a standalone build.