### PR TITLE
Add build-tools 35.0.0

### DIFF
--- a/tools/package-list-minimal.txt
+++ b/tools/package-list-minimal.txt
@@ -1,6 +1,7 @@
 build-tools;32.0.0
 build-tools;33.0.2
 build-tools;34.0.0
+build-tools;35.0.0
 cmake
 emulator
 extras;android;gapid;3

--- a/tools/package-list.txt
+++ b/tools/package-list.txt
@@ -4,6 +4,7 @@ add-ons;addon-google_apis-google-24
 build-tools;32.0.0
 build-tools;33.0.2
 build-tools;34.0.0
+build-tools;35.0.0
 cmake;3.10.2.4988404
 cmake;3.6.4111459
 docs


### PR DESCRIPTION
Add build-tools to support Android SDK 35. Related to https://github.com/mindrunner/docker-android-sdk/pull/106